### PR TITLE
Fixed a bug where the same column values have not been joined correctly in SQL.

### DIFF
--- a/into_query_derive/src/lib.rs
+++ b/into_query_derive/src/lib.rs
@@ -148,12 +148,8 @@ pub fn derive_into_query(input: TokenStream) -> TokenStream {
                 quote! {
                     if let Some(container) = self.#ident {
                         let mut iter = container.into_iter();
-                        if let Some(first) = iter.next() {
-                            query = query.filter(#ident.eq(first));
-                            for item in iter {
-                                query = query.or_filter(#ident.eq(item));
-                            }
-                        }
+                        let values = iter.collect::<Vec<_>>();
+                        query = query.filter(#ident.eq_any(values));
                     }
                 }
             } else {


### PR DESCRIPTION
Fixed a bug https://github.com/charliethomson/into_query/issues/3 where the same column values have not been joined correctly in SQL.

Slightly modified example data:
```rust
// model
#[derive(IntoQuery, Default)]
#[table_name = "users"]
pub struct FindUser {
    pub user_id: Option<Vec<i32>>, // NEW: multiple values
    pub username: Option<Vec<String>>, // NEW: multiple values
    pub display_name: Option<String>,
}

// main
fn find_user(name: String) -> QueryResult<Vec<models::User>> {
    let filter = models::FindUser {
        username: Some([name, "test1".into()].to_vec()), // NEW: multiple values
        user_id: Some([1, 2, 3].to_vec()), // NEW: multiple values
        ..models::FindUser::default()
    };

    let query = filter.into_query();
    let query_str = diesel::debug_query::<diesel::pg::Pg, _>(&query);
    println!("Built query: '{}'", query_str.to_string());

    return query.get_results::<User>(&establish_connection());
}
```

## Bug - Incorrect SQL:
SELECT "users"."user_id", "users"."username", "users"."display_name" FROM "users" WHERE ((("users"."user_id" = $1 OR "users"."user_id" = $2) OR "users"."user_id" = $3) **AND "users"."username" = $4 OR "users"."username" = $5**) -- binds: [1, 2, 3, "Testuser", "test1"]'

The issue is that username is not enclosed in parentheses:
 `AND "users"."username" = $4 OR "users"."username" = $5`

and it should be something like this:
`AND ("users"."username" = $4 OR "users"."username" = $5)`
OR
`AND "users"."username" IN ($4, $5)`

**As a proposed fix, I'm using `IN` as it gives equal or better performance than `OR`.**

## Fixed SQL:
SELECT "users"."user_id", "users"."username", "users"."display_name" FROM "users" WHERE "users"."user_id" **IN ($1, $2, $3)** AND "users"."username" **IN ($4, $5)** -- binds: [1, 2, 3, "Testuser", "test1"]


